### PR TITLE
Remove old worker pools when generating reports to keep only the active ones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+mozilla-history
+audit-worker-versions
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 mozilla-history
 audit-worker-versions
-
+!audit-worker-versions/main.go

--- a/README.md
+++ b/README.md
@@ -51,3 +51,11 @@ mozilla-history
 
 This will populate subdirectories `Clients`, `Hooks`, `Roles` and `WorkerPools`
 of the current directory.
+
+## Automating
+
+To automate the process, you can set up a cron job to execute `run-report.sh` at
+regular intervals.
+
+You would need to provide proper taskcluster credentials in the environment
+variables `TASKCLUSTER_CLIENT_ID`, `TASKCLUSTER_ACCESS_TOKEN`.

--- a/README.md
+++ b/README.md
@@ -29,12 +29,6 @@ This conversion avoids illegal filenames.
 Rather than creating nested subdirectories, this conversion avoids directory
 names colliding with entity filenames.
 
-## Entity update cadence
-
-The `mozilla-history` command is run every 5 mins from a raspberry pi in
-@petemoore's home network with the results committed to this repository and
-pushed to github.
-
 ## Installing
 
 ```
@@ -52,10 +46,21 @@ mozilla-history
 This will populate subdirectories `Clients`, `Hooks`, `Roles` and `WorkerPools`
 of the current directory.
 
-## Automating
+## Automating the Process
 
-To automate the process, you can set up a cron job to execute `run-report.sh` at
-regular intervals.
+You can automate this reporting process by setting up a cron job to execute `run-report.sh` at regular intervals.
 
-You would need to provide proper taskcluster credentials in the environment
-variables `TASKCLUSTER_CLIENT_ID`, `TASKCLUSTER_ACCESS_TOKEN`.
+### Prerequisites
+- Valid Taskcluster credentials must be set in the environment variables:
+  - `TASKCLUSTER_CLIENT_ID`
+  - `TASKCLUSTER_ACCESS_TOKEN`
+
+### How it works
+1. `run-report.sh` executes `audit.sh`
+2. `audit.sh` schedules tasks for each worker pool to extract worker implementation details from logs
+3. Results are stored in the `WorkerPools` directory
+4. `mozilla-history` stores Taskcluster configurations in their respective directories:
+   - Hooks definitions in `Hooks/`
+   - Roles definitions in `Roles/`
+   - WorkerPool definitions in `WorkerPool/`
+5. `build-docs-history.sh` generates a static page containing the version history

--- a/audit.sh
+++ b/audit.sh
@@ -20,4 +20,5 @@ sleep 5400
 echo "Generating reports"
 
 cd WorkerVersions
+find . -type f -not -name "workers.json" -delete # remove everything except workers.json
 audit-worker-versions "$TASK_GROUP_ID"

--- a/audit.sh
+++ b/audit.sh
@@ -20,5 +20,5 @@ sleep 5400
 echo "Generating reports"
 
 cd WorkerVersions
-find . -type f -not -name "workers.json" -delete # remove everything except workers.json
+find . -type f -delete
 audit-worker-versions "$TASK_GROUP_ID"

--- a/main.go
+++ b/main.go
@@ -212,6 +212,16 @@ func FetchWorkerPools(context *workerpool.SubmitterContext) {
 			panic(err)
 		}
 		for _, workerPool := range workerPools.WorkerPools {
+  		// Strip out fields that change frequently
+  		workerPool.RequestedCapacity = 0
+  		workerPool.RequestedCount = 0
+  		workerPool.RunningCapacity = 0
+  		workerPool.RunningCount = 0
+  		workerPool.StoppedCapacity = 0
+  		workerPool.StoppedCount = 0
+  		workerPool.StoppingCapacity = 0
+  		workerPool.StoppingCount = 0
+
 			context.RequestChannel <- WriteEntityToFileAsJSON(
 				workerPool,
 				filepath.Join("WorkerPools", FilenameEscape(workerPool.WorkerPoolID)),

--- a/run-reports.sh
+++ b/run-reports.sh
@@ -15,6 +15,7 @@ cd "$(dirname "${0}")"
 git pull
 
 echo "generating audit report"
+go build -buildvcs=false -o mozilla-history
 ./mozilla-history
 
 git add .

--- a/run-reports.sh
+++ b/run-reports.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+export TASKCLUSTER_ROOT_URL=https://firefox-ci-tc.services.mozilla.com/
+export REPORT_SCHEDULER_ID="smoketest"
+export REPORT_PREFIX=https://github.com/taskcluster/mozilla-history/blob/master/WorkerVersions/
+
+# needs to be set in the environment:
+# TASKCLUSTER_CLIENT_ID
+# TASKCLUSTER_ACCESS_TOKEN
+
+set -euo pipefail
+
+git pull
+
+echo "generating audit report"
+./mozilla-history
+
+git add .
+git commit -am "Audit report: $(date +'%Y-%m-%d %H:%M:%S')"
+
+echo "running worker versions report"
+./audit.sh
+
+git add .
+git commit -am "Worker versions report: $(date +'%Y-%m-%d %H:%M:%S')"
+
+# update history
+./build-docs-history.sh
+git add .
+git commit -v -a --no-edit --amend
+
+git push

--- a/run-reports.sh
+++ b/run-reports.sh
@@ -10,6 +10,8 @@ export REPORT_PREFIX=https://github.com/taskcluster/mozilla-history/blob/master/
 
 set -euo pipefail
 
+cd "$(dirname "${0}")"
+
 git pull
 
 echo "generating audit report"

--- a/run-reports.sh
+++ b/run-reports.sh
@@ -12,10 +12,15 @@ set -euo pipefail
 
 cd "$(dirname "${0}")"
 
+# build necessary tools with
+# go build -buildvcs=false -o mozilla-history
+# go build -buildvcs=false -o audit-worker-versions ./audit-worker-versions
+# or
+# go build ./...
+
 git pull
 
 echo "generating audit report"
-go build -buildvcs=false -o mozilla-history
 ./mozilla-history
 
 git add .


### PR DESCRIPTION
`run-reports.sh` is the script that can be used to collect all information from the deployment and run worker version audit tool